### PR TITLE
use M_PI instead of PI to support STRICT_R_HEADERS

### DIFF
--- a/src/partial.cpp
+++ b/src/partial.cpp
@@ -50,7 +50,7 @@ static double f_par_mu(double mu, void* args)
     double t = pm(mu, sigma, P, x_j, delta_ord);
 
     double res = t +
-	lambda * sigma * sqrt(2.0/PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
+	lambda * sigma * sqrt(2.0/M_PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
 	lambda * mu * (1.0 - 2.0 * R::pnorm(- mu/sigma, 0, 1, 1, 0));
 
     return res;
@@ -69,7 +69,7 @@ static double f_par_sig(double sigma, void* args)
     double t = pm(mu, sigma, P, x_j, delta_ord);
 
     double res = t +
-	lambda * sigma * sqrt(2.0/PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
+	lambda * sigma * sqrt(2.0/M_PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
 	lambda * mu * (1.0 - 2.0 * R::pnorm(- mu/sigma, 0, 1, 1, 0)) -
 	log(sigma);
 
@@ -127,9 +127,9 @@ double opt_par_gam(double mu, double sigma, double lambda, double a_0, double b_
     }
 
     double res = sigmoid(log(a_0 / b_0) + 0.5 - (
-	lambda * sigma * sqrt(2.0 / PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
+	lambda * sigma * sqrt(2.0 / M_PI) * exp(-pow(mu/sigma, 2.0) * 0.5) +
 	lambda * mu * (1.0 - 2.0 * R::pnorm(- mu/sigma, 0, 1, 1, 0)) +
-	log(sqrt(2.0 / PI) * 1.0 /(sigma * lambda)) + t)
+	log(sqrt(2.0 / M_PI) * 1.0 /(sigma * lambda)) + t)
     );
     
     return res;


### PR DESCRIPTION
Dear Michaek, dear survival.svb team,

Rcpp has been preparing for a new release (in the bi-annual schedule) in which `STRICT_R_HEADERS` will be on by default -- see [issue #1158 for all details](https://github.com/RcppCore/Rcpp/issues/1158). We have been at this since April (!!). The change requires prefixing a number of (potentially clashing) functions with `Rf_` and it affects a number of (old) `#define` statements and uses of _e.g._ `PI` (which must become `M_PI`).

Your package has a similar issue (that had not come up in prior roughlt monthly runs as your package is so new): in `src/partial.cpp you in four spots use `PI` but the preferred form is `M_PI`.

The PR makes the change, and allows survial.svb to build and test under the change from that upcoming Rcpp version. It would be great if you could fold the change in (really soon) as we plan to get this to CRAN next week.

Let me know if you have any questions.

Best, Dirk